### PR TITLE
Tagesdiagramm auch für mehr als 1 Monat lesbar

### DIFF
--- a/lib/src/forms/base-print.dart
+++ b/lib/src/forms/base-print.dart
@@ -1737,8 +1737,12 @@ abstract class BasePrint {
         "lineWidth": cm(lw),
         "lineColor": i > 0 ? lc : lcFrame
       });
+      if ((i == 0) ||     // das erste und letzte Datum bekommt auf jeden Fall einen Ausdrudk
+          (i == days.length - 1) ||
+          (days.length < 32) ||   // wenn es weniger als 32 Datum's hat, bekommt eh jedes Datum einen Ausdruck
+          ((i % 7) == 0))         // ansonsten gibt es nur wöchentliche Ausdrucke
       horzStack.add({
-        "relativePosition": {"x": cm(xorg + i * ret.colWidth - 0.5), "y": cm(yorg + graphBottom + 0.05)},
+        "relativePosition": {"x": cm(xorg + i * ret.colWidth - 0.4), "y": cm(yorg + graphBottom + 0.05)},
         "text": fmtDateShort(days[i].date),
         "fontSize": fs(8)
       });

--- a/lib/src/forms/print-daily-statistics.dart
+++ b/lib/src/forms/print-daily-statistics.dart
@@ -300,9 +300,7 @@ class PrintDailyStatistics extends BasePrint {
     double yo = yorg;
     insulinMax = -1000.0;
     graphWidth = 23.25;
-    graphHeight = 6.5;
-    graphHeight += 4;
-    graphHeight += 2.5;
+    graphHeight = 6;
     graphBottom = graphHeight;
     insulinTableTop = graphHeight;
     lineWidth = cm(0.03);


### PR DESCRIPTION
Tagesdiagramm auf 6cm Höhe zusammengedampft um Platz für Wochen- und Monatsübersichten zu schaffen